### PR TITLE
fix: harden backend security — auth, validation, CORS, rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,12 @@
 FIREBASE_CREDENTIALS=
 APP_ENV=local
+
+# Required: Must match NEXTAUTH_SECRET from frontend .env
+# Used to decrypt NextAuth.js session tokens
+# Generate with: openssl rand -base64 32
+NEXTAUTH_SECRET=
+
+# Comma-separated list of allowed origins for CORS
+# Production: https://www.corgiplanningpoker.com
+# Development: http://localhost:3000
+ALLOWED_ORIGINS=http://localhost:3000

--- a/configs/config.go
+++ b/configs/config.go
@@ -9,6 +9,7 @@ type config struct {
 	FirebaseCredentials string `env:"FIREBASE_CREDENTIALS,required"`
 	AuthSecret          string `env:"NEXTAUTH_SECRET,required"`
 	AppEnv              string `env:"APP_ENV" envDefault:"production"`
+	AllowedOrigins      string `env:"ALLOWED_ORIGINS" envDefault:"http://localhost:3000"`
 }
 
 var Conf config

--- a/go.mod
+++ b/go.mod
@@ -43,9 +43,11 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.51.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
+github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -131,6 +133,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
+github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.51.0 h1:8b30A5JlZ6C7AS81RsWjYMQmrZG6feChmgAolCl1SqA=
@@ -162,6 +166,7 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -171,6 +176,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.3.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
 golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -180,6 +186,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -191,15 +198,18 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
@@ -211,6 +221,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.4.0/go.mod h1:UE5sM2OK9E/d67R0ANs2xJizIymRP5gJU295PvKXxjQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=

--- a/internal/core/auth/websocket/auth.go
+++ b/internal/core/auth/websocket/auth.go
@@ -1,0 +1,38 @@
+package websocketauth
+
+import (
+	"errors"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/raksitnongbua/planning-poker-service/constants"
+	"github.com/raksitnongbua/planning-poker-service/internal/core/usecase/profile"
+)
+
+// ExtractAuthenticatedUID extracts and verifies the user ID from authentication cookies.
+// Checks NextAuth session cookie first (authenticated users), falls back to guest UID cookie.
+// Returns the authenticated UID and an error if no valid authentication is found.
+func ExtractAuthenticatedUID(c *fiber.Ctx) (string, error) {
+	// Try NextAuth session cookie first (authenticated users)
+	var sessionCookie string
+	if c.Secure() {
+		sessionCookie = c.Cookies(constants.SecureSessionCookie)
+	} else {
+		sessionCookie = c.Cookies(constants.SessionCookie)
+	}
+
+	if sessionCookie != "" {
+		p, err := profile.GetProfile(sessionCookie)
+		if err == nil && p != nil && p.UID != "" {
+			return p.UID, nil
+		}
+		// If decryption fails, fall through to check guest cookie
+	}
+
+	// Fall back to guest UID cookie
+	guestUID := c.Cookies("CPPUniID")
+	if guestUID != "" {
+		return guestUID, nil
+	}
+
+	return "", errors.New("no valid authentication found")
+}

--- a/internal/core/handler/room/room_request_dto.go
+++ b/internal/core/handler/room/room_request_dto.go
@@ -1,6 +1,9 @@
 package room
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+)
 
 type roomRequest struct {
 	RoomName   string `json:"room_name"`
@@ -11,5 +14,28 @@ type roomRequest struct {
 func unmarshalRoomRequest(data []byte) (roomRequest, error) {
 	var r roomRequest
 	err := json.Unmarshal(data, &r)
-	return r, err
+	if err != nil {
+		return r, err
+	}
+
+	// Input validation (security: prevent resource exhaustion and DB bloat)
+	if err := r.Validate(); err != nil {
+		return r, err
+	}
+
+	return r, nil
+}
+
+// Validate performs security input validation on room request fields
+func (r *roomRequest) Validate() error {
+	if len(r.RoomName) > 100 {
+		return errors.New("room_name exceeds 100 characters")
+	}
+	if len(r.DeskConfig) > 500 {
+		return errors.New("desk_config exceeds 500 characters")
+	}
+	if len(r.HostingID) > 150 {
+		return errors.New("hosting_id exceeds 150 characters")
+	}
+	return nil
 }

--- a/internal/core/handler/room_socket/room_socket_handler.go
+++ b/internal/core/handler/room_socket/room_socket_handler.go
@@ -124,8 +124,12 @@ func SocketRoomHandler(c *websocket.Conn) {
 	)
 	for {
 		if _, msg, err = c.ReadMessage(); err != nil {
-			logger.Error("ws read error", "roomId", roomId, "uid", uid, "error", err)
-			break // Network error - connection broken, must disconnect
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
+				logger.Error("ws read error", "roomId", roomId, "uid", uid, "error", err)
+			} else {
+				logger.Info("ws client closed connection", "roomId", roomId, "uid", uid)
+			}
+			break
 		}
 		var receivedMessage messageAction
 		if err := json.Unmarshal(msg, &receivedMessage); err != nil {

--- a/internal/core/handler/room_socket/room_socket_handler.go
+++ b/internal/core/handler/room_socket/room_socket_handler.go
@@ -61,6 +61,15 @@ func noticeUpdateRoom(roomId string, roomInfo domain.Room) {
 }
 
 func SocketRoomHandler(c *websocket.Conn) {
+	// Panic recovery middleware (security: prevent server crash from malformed messages)
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("panic in WebSocket handler", "panic", r)
+			_ = c.WriteJSON(fiber.Map{"error": "INTERNAL_ERROR"})
+			_ = c.Close()
+		}
+	}()
+
 	roomId := c.Params("id")
 
 	if !roomService.IsRoomExists(roomId) {
@@ -70,11 +79,27 @@ func SocketRoomHandler(c *websocket.Conn) {
 		return
 	}
 
+	// Phase 1: Try cookie auth first, fallback to URL param (security: monitoring)
+	// Phase 2 will reject connections without cookie auth after metrics confirm it works
+	var uid string
+	authenticatedUID, ok := c.Locals("authenticated_uid").(string)
+	if ok && authenticatedUID != "" {
+		// Cookie auth successful - use authenticated UID
+		uid = authenticatedUID
+		logger.Info("using cookie-authenticated uid", "roomId", roomId, "uid", uid)
+	} else {
+		// Fallback to URL param (temporary for Phase 1)
+		uid = c.Params("uid")
+		logger.Warn("using url param uid (cookie auth failed)", "roomId", roomId, "uid", uid)
+	}
+
+	// Set roomId in Locals before adding to clients map (security: fix race condition)
+	c.Locals("roomId", roomId)
+
 	clientsMu.Lock()
 	clients[c] = true
 	clientsMu.Unlock()
 
-	uid := c.Params("uid")
 	logger.Info("ws client connected", "roomId", roomId, "uid", uid)
 
 	defer func() {
@@ -85,7 +110,6 @@ func SocketRoomHandler(c *websocket.Conn) {
 		logger.Info("ws client disconnected", "roomId", roomId, "uid", uid)
 		_ = c.Close()
 	}()
-	c.Locals("roomId", roomId)
 
 	roomInfo := roomService.GetRoomInfo(roomId)
 
@@ -101,12 +125,13 @@ func SocketRoomHandler(c *websocket.Conn) {
 	for {
 		if _, msg, err = c.ReadMessage(); err != nil {
 			logger.Error("ws read error", "roomId", roomId, "uid", uid, "error", err)
-			break
+			break // Network error - connection broken, must disconnect
 		}
 		var receivedMessage messageAction
 		if err := json.Unmarshal(msg, &receivedMessage); err != nil {
 			logger.Error("ws unmarshal error", "roomId", roomId, "uid", uid, "error", err)
-			break
+			_ = c.WriteJSON(fiber.Map{"error": "INVALID_MESSAGE_FORMAT"})
+			continue // Recoverable error - keep connection alive
 		}
 
 		if receivedMessage.Action != "PING" {
@@ -117,14 +142,14 @@ func SocketRoomHandler(c *websocket.Conn) {
 		case "JOIN_ROOM":
 			joinRoomPayload, err := transformPayloadToJoinRoom(receivedMessage.Payload)
 			if err != nil {
-				c.WriteJSON(fiber.Map{"error": "INVALID_PAYLOAD"})
-				return
+				_ = c.WriteJSON(fiber.Map{"error": "INVALID_PAYLOAD", "details": err.Error()})
+				continue // Validation error - keep connection alive
 			}
 			roomInfo, err := socketService.JoinRoom(uid, joinRoomPayload.Name, joinRoomPayload.Profile, roomId)
 			if err != nil {
 				logger.Error("JOIN_ROOM failed", "roomId", roomId, "uid", uid, "error", err)
-				c.WriteJSON(fiber.Map{"error": "JOIN_ROOM_FAILED"})
-				return
+				_ = c.WriteJSON(fiber.Map{"error": "JOIN_ROOM_FAILED"})
+				continue // Service error - keep connection alive
 			}
 			noticeUpdateRoom(roomId, roomInfo)
 
@@ -134,20 +159,20 @@ func SocketRoomHandler(c *websocket.Conn) {
 			if index != -1 {
 				estimatedPayload, err := transformPayloadToEstimatedPoint(receivedMessage.Payload)
 				if err != nil {
-					c.WriteJSON(fiber.Map{"error": "INVALID_PAYLOAD"})
-					return
+					_ = c.WriteJSON(fiber.Map{"error": "INVALID_PAYLOAD", "details": err.Error()})
+					continue // Validation error - keep connection alive
 				}
 				roomInfo, err := socketService.UpdateEstimatedValue(index, estimatedPayload.Value, roomId)
 
 				if err != nil {
 					logger.Error("UPDATE_ESTIMATED_VALUE failed", "roomId", roomId, "uid", uid, "error", err)
-					c.WriteJSON(fiber.Map{"error": "UPDATE_ESTIMATED_VALUE_FAILED"})
-					return
+					_ = c.WriteJSON(fiber.Map{"error": "UPDATE_ESTIMATED_VALUE_FAILED"})
+					continue // Service error - keep connection alive
 				}
 				noticeUpdateRoom(roomId, roomInfo)
 
 			} else {
-				c.WriteJSON(fiber.Map{"error": "NOT_FOUND_USER"})
+				_ = c.WriteJSON(fiber.Map{"error": "NOT_FOUND_USER"})
 			}
 		case "REVEAL_CARDS":
 			roomInfo = roomService.GetRoomInfo(roomId)
@@ -156,13 +181,13 @@ func SocketRoomHandler(c *websocket.Conn) {
 				roomInfo, err := socketService.RevealCards(index, roomId)
 				if err != nil {
 					logger.Error("REVEAL_CARDS failed", "roomId", roomId, "uid", uid, "error", err)
-					c.WriteJSON(fiber.Map{"error": "REVEAL_CARDS_FAILED"})
-					return
+					_ = c.WriteJSON(fiber.Map{"error": "REVEAL_CARDS_FAILED"})
+					continue // Service error - keep connection alive
 				}
 
 				noticeUpdateRoom(roomId, roomInfo)
 			} else {
-				c.WriteJSON(fiber.Map{"error": "NOT_FOUND_USER"})
+				_ = c.WriteJSON(fiber.Map{"error": "NOT_FOUND_USER"})
 			}
 
 		case "NEXT_ROUND":
@@ -202,8 +227,8 @@ func SocketRoomHandler(c *websocket.Conn) {
 			}
 			if err != nil {
 				logger.Error("NEXT_ROUND failed", "roomId", roomId, "error", err)
-				c.WriteJSON(fiber.Map{"error": "NEXT_ROUND_FAILED"})
-				return
+				_ = c.WriteJSON(fiber.Map{"error": "NEXT_ROUND_FAILED"})
+				continue // Service error - keep connection alive
 			}
 			noticeUpdateRoom(roomId, roomInfo)
 

--- a/internal/core/handler/room_socket/room_socket_transformer.go
+++ b/internal/core/handler/room_socket/room_socket_transformer.go
@@ -144,5 +144,13 @@ func transformPayloadToJoinRoom(payload interface{}) (data joinRoomPayload, err 
 		return joinRoomPayload{}, fmt.Errorf("Error unmarshal payload: %d", err)
 	}
 
+	// Input validation (security: prevent resource exhaustion and XSS)
+	if len(joinRoomData.Name) == 0 || len(joinRoomData.Name) > 100 {
+		return joinRoomPayload{}, fmt.Errorf("name must be 1-100 characters")
+	}
+	if len(joinRoomData.Profile) > 500 {
+		return joinRoomPayload{}, fmt.Errorf("profile URL too long (max 500)")
+	}
+
 	return joinRoomData, nil
 }

--- a/internal/core/usecase/id_generator/id_generator.go
+++ b/internal/core/usecase/id_generator/id_generator.go
@@ -1,7 +1,8 @@
 package idgenerator
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"strings"
 	"time"
 
@@ -17,12 +18,16 @@ func GenerateUniqueRoomID() string {
 
 func generateRandomString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-	runes := []rune(charset)
-	b := make([]rune, length)
-	for i := range b {
-		b[i] = runes[rand.Intn(len(runes))]
+	result := make([]byte, length)
+	for i := range result {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			// Critical: UUID generation must not fail. Panic to prevent insecure fallback.
+			panic("crypto/rand failure: " + err.Error())
+		}
+		result[i] = charset[num.Int64()]
 	}
-	return string(b)
+	return string(result)
 }
 
 func GenerateUUID() string {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -23,6 +23,10 @@ func Info(msg string, args ...any) {
 	Logger.Info(msg, args...)
 }
 
+func Warn(msg string, args ...any) {
+	Logger.Warn(msg, args...)
+}
+
 func Error(msg string, args ...any) {
 	Logger.Error(msg, args...)
 }

--- a/protocol/http.go
+++ b/protocol/http.go
@@ -2,12 +2,15 @@ package protocol
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gofiber/contrib/websocket"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2/middleware/limiter"
 
 	"github.com/raksitnongbua/planning-poker-service/configs"
+	websocketauth "github.com/raksitnongbua/planning-poker-service/internal/core/auth/websocket"
 	"github.com/raksitnongbua/planning-poker-service/internal/core/handler/health"
 	"github.com/raksitnongbua/planning-poker-service/internal/core/handler/room"
 	roomsocket "github.com/raksitnongbua/planning-poker-service/internal/core/handler/room_socket"
@@ -16,21 +19,70 @@ import (
 )
 
 func ServeREST() {
-	app := fiber.New()
-	app.Use(cors.New())
+	app := fiber.New(fiber.Config{
+		BodyLimit: 1 * 1024 * 1024, // 1MB max request body (security: prevent memory exhaustion)
+	})
+
+	// CORS configuration with explicit allowed origins (security: prevent CSRF)
+	app.Use(cors.New(cors.Config{
+		AllowOrigins:     configs.Conf.AllowedOrigins,
+		AllowMethods:     "GET,POST,DELETE",
+		AllowHeaders:     "Content-Type,Cookie",
+		AllowCredentials: true,
+		MaxAge:           86400, // 24 hours
+	}))
+
+	// Rate limiting for HTTP endpoints (security: prevent resource exhaustion)
+	// 200 requests per minute per IP
+	app.Use(limiter.New(limiter.Config{
+		Max:        200,
+		Expiration: 1 * time.Minute,
+		KeyGenerator: func(c *fiber.Ctx) string {
+			return c.IP() // Rate limit by client IP
+		},
+		LimitReached: func(c *fiber.Ctx) error {
+			logger.Warn("rate limit exceeded", "ip", c.IP(), "path", c.Path())
+			return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+				"error": "Rate limit exceeded. Please try again later.",
+			})
+		},
+		SkipFailedRequests:     false,
+		SkipSuccessfulRequests: false,
+		Storage:                nil, // Uses in-memory storage
+	}))
+
 	app.Get("/health", health.HealthCheckHandler)
 	app.Static("/openapi.yaml", "./openapi.yaml")
 	app.Get("/docs", docsHandler)
 
+	// WebSocket authentication middleware - Phase 1: log-only mode (security: monitoring cookie auth)
+	// Phase 2 (rejection) will be enabled after 48h metrics confirm cookie transmission works
 	app.Use("/ws", func(c *fiber.Ctx) error {
-		if websocket.IsWebSocketUpgrade(c) {
-			c.Locals("allowed", true)
-			return c.Next()
+		if !websocket.IsWebSocketUpgrade(c) {
+			return fiber.ErrUpgradeRequired
 		}
-		return fiber.ErrUpgradeRequired
+
+		// Try to authenticate from cookies (NextAuth session or guest UID)
+		authenticatedUID, err := websocketauth.ExtractAuthenticatedUID(c)
+		if err != nil {
+			// Phase 1: Log but allow connection (fallback to URL param in handler)
+			logger.Warn("websocket auth from cookie failed - falling back to URL param",
+				"error", err, "path", c.Path(), "remote_addr", c.IP())
+		} else {
+			// Success: cookie auth worked
+			logger.Info("websocket auth from cookie successful", "uid", authenticatedUID, "remote_addr", c.IP())
+			c.Locals("authenticated_uid", authenticatedUID)
+		}
+
+		c.Locals("allowed", true)
+		return c.Next()
 	})
 
-	app.Get("/ws/room/:uid/:id", websocket.New(roomsocket.SocketRoomHandler))
+	// WebSocket configuration with security limits
+	app.Get("/ws/room/:uid/:id", websocket.New(roomsocket.SocketRoomHandler, websocket.Config{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}))
 
 	api := app.Group("/api")
 	v1 := api.Group("v1")


### PR DESCRIPTION
## Summary
- Harden WebSocket auth: read `CPPUniID` / NextAuth session cookie on upgrade, fall back to URL param with a WARN if missing
- Add input validation, CORS allowlist, and rate limiting (200 req/min per IP)
- Fix: use `IsUnexpectedCloseError` to distinguish intentional browser disconnects (1001 going away, 1000 normal close) from real errors — normal closes now log at INFO instead of ERROR

## Test plan
Verified end-to-end with a Playwright script (`e2e/ws-auth.spec.ts`):
- [x] `CPPUniID` cookie sent with WebSocket upgrade request from browser
- [x] Backend logs `websocket auth from cookie successful` — UID from cookie matches session UID
- [x] No fallback to URL param on normal load
- [x] Normal browser disconnect (page close / reload) logs at INFO as `ws client closed connection`, not ERROR
- [x] Room loads successfully — join dialog visible after WebSocket connection established

🤖 Generated with [Claude Code](https://claude.ai/claude-code)